### PR TITLE
Update to use argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Run pillory on the current directory:
 python -m pillory
 ```
 
-Or give a specific file, directory, or glob:
+Or give a specific files and directories:
 
 ```
-python -m pillory 'tests/**/test_*.py'
+python -m pillory tests/ test_example.py
 ```
 
 ### Rules
@@ -67,14 +67,12 @@ and it still has problems with test isolation.
 
 ## Known issues
 
-* No --help text.
 * No console script entry point (pillory command), have to use with python -m.
-* Only takes one path or glob.
+* Does not have a non-zero exit code when errors found.
 * Only tested with Python 3.10.
 * No config file support.
 * No comments to ignore rules.
 * Not fast.
-* Globs have to be relative to the current directory.
 * No further explanations for the errors.
 * No pretty error handling, just tracebacks.
 * Will error when mocking something in the module under test, which is arguably

--- a/pillory.py
+++ b/pillory.py
@@ -1,9 +1,10 @@
 """A linter to scrutinize how you are using mocks in Python."""
 
-__version__ = "1.1.4"
+__version__ = "2.0.0"
 
 # pyright: strict
 
+import argparse
 import ast
 import functools
 import logging
@@ -293,17 +294,28 @@ def format_message(path: str, lineno: int, col_offset: int, rule_code: str, arg:
     return f"{path}:{lineno}:{col_offset}: {rule_code} {RULE_MESSAGES[rule_code]} {arg}"
 
 
+def make_arg_parser() -> argparse.ArgumentParser:
+    """Create an argument parser for the command line interface."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="*",
+        default=(".",),
+        help="The files to lint. Directories are searched recursively. The default is the current directory.",
+    )
+    return parser
+
+
 def main(argv: list[str]):
     """
     Find files, parse them, and print output.
 
     This should be used from an if __name__ == "__main__" block and passed sys.argv.
     """
-    if len(argv) > 1 and argv[1] != ".":
-        start_dir = argv[1]
-    else:
-        start_dir = "."
-    for file in walk_path(pathlib.Path(start_dir)):
+    arg_parser = make_arg_parser()
+    args = arg_parser.parse_args(argv[1:])
+    files = [file for path in args.path for file in walk_path(pathlib.Path(path))]
+    for file in files:
         try:
             source = file.read_text()
         except Exception:


### PR DESCRIPTION
Adds --help for free. Will be useful when needing to pass things like
ignores and config files. Removed the glob thing for specific files
instead (more usable in pre-commit). Because removing globs change the
CLI interface, moved to 2.0.0.
